### PR TITLE
Reorganize Courses by Fulfillment

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,9 +87,39 @@
 					</ul>
 				</details>
 			</div>
-		<details>
+		</details>
 		<details open>
-			<summary>Courses</summary>
+			<summary>CS Math Collateral</summary>
+			<div class="courses">
+				<details><summary>MATH 125: Precalculus</summary>
+					<ul>
+						<li><p><a href="./courses/MATH_125/MATH125_grote_syllabus_s18.pdf" target="_blank">Matthew Grote (s18)</a></p></li>
+					</ul>
+				</details>
+				<details><summary>MATH 150: Calculus I</summary>
+					<ul>
+						<li><p><a href="./courses/MATH_150/MATH150_shneerson_syllabus_f15.pdf" target="_blank">Lev Shneerson (f15)</a></p></li>
+					</ul>
+				</details>
+				<details><summary>MATH 155: Calculus II</summary>
+					<ul>
+						<li><p><a href="./courses/MATH_155/MATH155_syllabus.pdf" target="_blank">Jane Doe</a></p></li>
+					</ul>
+				</details>
+				<details><summary>MATH 160: Matrix Algebra</summary>
+					<ul>
+						<li><p><a href="./courses/MATH_160/MATH160_song_syllabus_f19.pdf" target="_blank">Connor Song (f19)</a></p></li>
+					</ul>
+				</details>
+				<details><summary>STAT 213: Introduction to Applied Statistics</summary>
+					<ul>
+						<li><p><a href="./courses/STAT_213/STAT213_jalayer_syllabus_f19.pdf" target="_blank">Ardalan Jalayer (f19)</a></p></li>
+					</ul>
+				</details>
+			</div>
+		</details>
+		<details open>
+			<summary>CS Electives</summary>
 			<div class="courses">
 				<details><summary>CSCI 267: Microprocessing & Embedded Systems</summary>
 					<ul>
@@ -287,31 +317,6 @@
 					<!-- <ul>
 						<li><p><a href="./courses/CS_49380/" target="_blank"></a></p></li>
 					</ul> -->
-				</details>
-				<details><summary>MATH 125: Precalculus</summary>
-					<ul>
-						<li><p><a href="./courses/MATH_125/MATH125_grote_syllabus_s18.pdf" target="_blank">Matthew Grote (s18)</a></p></li>
-					</ul>
-				</details>
-				<details><summary>MATH 150: Calculus I</summary>
-					<ul>
-						<li><p><a href="./courses/MATH_150/MATH150_shneerson_syllabus_f15.pdf" target="_blank">Lev Shneerson (f15)</a></p></li>
-					</ul>
-				</details>
-				<details><summary>MATH 155: Calculus II</summary>
-					<ul>
-						<li><p><a href="./courses/MATH_155/MATH155_syllabus.pdf" target="_blank">Jane Doe</a></p></li>
-					</ul>
-				</details>
-				<details><summary>MATH 160: Matrix Algebra</summary>
-					<ul>
-						<li><p><a href="./courses/MATH_160/MATH160_song_syllabus_f19.pdf" target="_blank">Connor Song (f19)</a></p></li>
-					</ul>
-				</details>
-				<details><summary>STAT 213: Introduction to Applied Statistics</summary>
-					<ul>
-						<li><p><a href="./courses/STAT_213/STAT213_jalayer_syllabus_f19.pdf" target="_blank">Ardalan Jalayer (f19)</a></p></li>
-					</ul>
 				</details>
 				<details><summary>CSCI 71010: Programming Languages and Their Implementation</summary>
 					<!-- <ul>

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
 
 	<div id="container">
 		<details open>
-			<summary>Courses</summary>
+			<summary>CS Major Core Courses</summary>
 			<div class="courses">
 				<details><summary>CSCI 127: Introduction to Computer Science</summary>
 					<ul>
@@ -73,17 +73,6 @@
 						<li><p><a href="./courses/CS_265/CS265_canizales_syllabus_s20.pdf" target="_blank">Jamie Canizales (s20)</a></p></li>
 					</ul>
 				</details>
-				<details><summary>CSCI 267: Microprocessing & Embedded Systems</summary>
-					<ul>
-						<li><p><a href="./courses/CS_267/CS267_embedded_systems_schweitzer_syllabus_f19.pdf" target="_blank">Eric Schweitzer (f19)</a></p></li>
-					</ul>
-				</details>
-				<details><summary>CSCI 275: Symbolic Logic</summary>
-					<ul>
-						<li><p><a href="./courses/CS_275/CS275_symbolic_logic_harris_syllabus_f17.pdf" target="_blank">Daniel Harris(f17)</a></p></li>
-						<li><p><a href="./courses/CS_275/CS275_Symbolic_Logic_Addison_syllabus_s20.pdf" target="_blank">Daniel Addison(s20)</a></p></li>
-					</ul>
-				</details>
 				<details><summary>CSCI 335: Software Analysis &amp; Design III</summary>
 					<ul>
 						<li><p><a href="./courses/CS_335/CS335_weiss_syllabus_s19.pdf" target="_blank">Stewart Weiss (s19)</a></p></li>
@@ -97,7 +86,23 @@
 						<li><p><a href="./courses/CS_340/CS340_shostak_syllabus_s20.pdf" target="_blank">Pavel Shostak (s20)</a></p></li>
 					</ul>
 				</details>
-					<details><summary>CSCI 350: Artificial Intelligence</summary>
+			</div>
+		<details>
+		<details open>
+			<summary>Courses</summary>
+			<div class="courses">
+				<details><summary>CSCI 267: Microprocessing & Embedded Systems</summary>
+					<ul>
+						<li><p><a href="./courses/CS_267/CS267_embedded_systems_schweitzer_syllabus_f19.pdf" target="_blank">Eric Schweitzer (f19)</a></p></li>
+					</ul>
+				</details>
+				<details><summary>CSCI 275: Symbolic Logic</summary>
+					<ul>
+						<li><p><a href="./courses/CS_275/CS275_symbolic_logic_harris_syllabus_f17.pdf" target="_blank">Daniel Harris(f17)</a></p></li>
+						<li><p><a href="./courses/CS_275/CS275_Symbolic_Logic_Addison_syllabus_s20.pdf" target="_blank">Daniel Addison(s20)</a></p></li>
+					</ul>
+				</details>
+				<details><summary>CSCI 350: Artificial Intelligence</summary>
 					<ul>
 						<li><p><a href="./courses/CS_350/CS350_artificial_intelligence_raja_syllabus_s20.pdf" target="_blank">Anita Raja (s20)</a></p></li>
 					</ul>


### PR DESCRIPTION
Split into Core Courses for the Major, Math Collateral Requirements, and electives. Cool idea btw don't know how this hasn't been made yet.