### PR TITLE
chore(github actions): upgrade deprecated actions

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
       - name: Build artifact
         run: >
           for department in `ls syllabi`; do
@@ -42,10 +42,10 @@ jobs:
       - name: Set landing page to CS syllabi page
         run: cp cs.html index.html
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v4
         with:
           # Upload entire repository
           path: '.'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v3
       - name: Build artifact
         run: >
           for department in `ls syllabi`; do
@@ -42,10 +42,10 @@ jobs:
       - name: Set landing page to CS syllabi page
         run: cp cs.html index.html
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
           path: '.'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v3


### PR DESCRIPTION
> This request has been automatically failed because it uses a deprecated
> version of `actions/upload-artifact: v3`. Learn more:
> https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/